### PR TITLE
Add settings module with error handling & common requests wrapper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -157,4 +157,4 @@ const login = new Login('#login');
 const registration = new Registration('#registration');
 // eslint shows errors without console.log (no-unused-vars)
 console.log(login);
-console.log(registration)
+console.log(registration);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,10 +1,30 @@
 import Api from './api';
+import Settings from './settings';
 
+// 1. Check login
 const api = new Api();
 
-api.checkLogin().then((user) => {
+api.checkLogin().then(async (user) => {
   // Already logged in
   console.log(user);
+
+  // 2. Get settings
+  const settings = new Settings();
+
+  await settings.getSettings(); // get settings from backend & set them to the instance of Settings
+  // await settings.initSettings(); // use this for first initialization of the new user
+  console.log(JSON.stringify(settings)); // see what is stored in settings instance
+
+  // Example of how update some field of the minigame
+  // const { minigames: { speakit } } = settings;
+
+  // speakit.difficulty = 4;
+
+  // await settings.update('speakit', speakit);
+
+  // Example of how update learningMode field
+  // await settings.update('learningMode', 'mix');
 }, () => {
   // Redirect to login
+  // window.location.href = '/';
 });

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -1,0 +1,213 @@
+import performRequests from 'app/js/utils/perform-requests';
+import Api from 'app/js/api';
+
+class Settings {
+  constructor() {
+    this.api = new Api();
+
+    this.minigames = {
+      speakit: {
+        isMute: undefined, // false
+        round: undefined, // 0
+        difficulty: undefined, // 0
+      },
+      englishPuzzle: {
+        isMute: undefined, // false
+        round: undefined, // 0
+        difficulty: undefined, // 0
+      },
+      savannah: {
+        isMute: undefined, // false
+        round: undefined, // 0
+        difficulty: undefined, // 0
+      },
+      audioCall: {
+        isMute: undefined, // false
+        round: undefined, // 0
+        difficulty: undefined, // 0
+      },
+      sprint: {
+        isMute: undefined, // false
+        round: undefined, // 0
+        difficulty: undefined, // 0
+      },
+      ourGame: {
+        isMute: undefined, // false
+        round: undefined, // 0
+        difficulty: undefined, // 0
+      },
+    };
+    this.isGlobalMute = undefined; // false
+    this.wordsPerDay = undefined; // 20
+    this.learningMode = undefined; // new|old|mix
+    this.countNewWords = undefined; // 10
+    this.definitionSentence = undefined; // false
+    this.exampleSentence = undefined; // false
+    this.translateWord = undefined; // false
+    this.associationImage = undefined; // false
+    this.transcription = undefined; // false
+    this.answerButton = undefined; // false
+    this.deleteButton = undefined; // false
+    this.addToHardWordsButton = undefined; // false
+  }
+
+  /**
+   * Use this if you need to initialize settings for new user.
+   */
+  async initSettings() {
+    this.setSettings();
+    await this.postUpdates();
+  }
+
+  async getSettings() {
+    const settings = await performRequests([this.api.getSettings()]);
+
+    if (settings) {
+      this.setSettings(...settings); // Promise.all returns array of resolved/rejected promises
+    }
+  }
+
+  /**
+   * Parses the given settings & sets their fields with data into instance of class.
+   * @param {Object} settings stores settings usually from backend
+   */
+  setSettings(settings = {}) {
+    console.log(settings);
+    const {
+      wordsPerDay = 20,
+      optional: {
+        minigames = {
+          speakit: {
+            isMute: false,
+            round: 0,
+            difficulty: 0,
+          },
+          englishPuzzle: {
+            isMute: false,
+            round: 0,
+            difficulty: 0,
+          },
+          savannah: {
+            isMute: false,
+            round: 0,
+            difficulty: 0,
+          },
+          audioCall: {
+            isMute: false,
+            round: 0,
+            difficulty: 0,
+          },
+          sprint: {
+            isMute: false,
+            round: 0,
+            difficulty: 0,
+          },
+          ourGame: {
+            isMute: false,
+            round: 0,
+            difficulty: 0,
+          },
+        },
+        isGlobalMute = false,
+        learningMode = 'mix',
+        countNewWords = 10,
+        definitionSentence = false,
+        exampleSentence = false,
+        translateWord = false,
+        associationImage = false,
+        transcription = false,
+        answerButton = false,
+        deleteButton = false,
+        addToHardWordsButton = false,
+      } = {},
+    } = settings;
+
+    this.wordsPerDay = wordsPerDay;
+    this.minigames = minigames;
+    this.isGlobalMute = isGlobalMute;
+    this.learningMode = learningMode;
+    this.countNewWords = countNewWords;
+    this.definitionSentence = definitionSentence;
+    this.exampleSentence = exampleSentence;
+    this.translateWord = translateWord;
+    this.associationImage = associationImage;
+    this.transcription = transcription;
+    this.answerButton = answerButton;
+    this.deleteButton = deleteButton;
+    this.addToHardWordsButton = addToHardWordsButton;
+  }
+
+  /**
+   * Update local instance of class & send these update to the server.
+   * @param {String} key name of the field which must be updated @see localUpdates()
+   * @param {*} value what must be set
+   */
+  async update(key, value) {
+    this.localUpdates(key, value);
+    await this.postUpdates();
+  }
+
+  localUpdates(key, value) {
+    switch (key) {
+      case 'speakit':
+      case 'englishPuzzle':
+      case 'savannah':
+      case 'audioCall':
+      case 'sprint':
+      case 'ourGame':
+        this.minigames[key] = value;
+        break;
+      default:
+        this[key] = value;
+        break;
+    }
+  }
+
+  /**
+   * Synchronizes settings with backend API.
+   */
+  async postUpdates() {
+    const {
+      wordsPerDay,
+      minigames,
+      isGlobalMute,
+      learningMode,
+      countNewWords,
+      definitionSentence,
+      exampleSentence,
+      translateWord,
+      associationImage,
+      transcription,
+      answerButton,
+      deleteButton,
+      addToHardWordsButton,
+    } = this;
+
+    const settings = {
+      wordsPerDay,
+      optional: {
+        minigames,
+        isGlobalMute,
+        learningMode,
+        countNewWords,
+        definitionSentence,
+        exampleSentence,
+        translateWord,
+        associationImage,
+        transcription,
+        answerButton,
+        deleteButton,
+        addToHardWordsButton,
+      },
+    };
+
+    const response = await performRequests([this.api.upsertSettings(settings)]);
+
+    if (response) {
+      // Promise.all returns array of resolved/rejected promises
+      console.log('Ответ: ', ...response);
+    }
+  }
+}
+
+export default Settings;

--- a/src/js/utils/errors-handler.js
+++ b/src/js/utils/errors-handler.js
@@ -1,0 +1,45 @@
+const errorHandler = {
+  errorInfoElement: null,
+  timerId: null,
+
+  initElements() {
+    const ERROR_INFO_MESSAGE_CLASSNAME = 'error-info-message';
+
+    [this.errorInfoElement] = document.getElementsByClassName(ERROR_INFO_MESSAGE_CLASSNAME);
+
+    if (!this.errorInfoElement) {
+      const errorInfoElement = document.createElement('p');
+
+      errorInfoElement.classList.add(ERROR_INFO_MESSAGE_CLASSNAME);
+      errorInfoElement.hidden = true;
+      document.body.prepend(errorInfoElement);
+
+      this.errorInfoElement = errorInfoElement;
+    }
+  },
+
+  handle(err) {
+    this.initElements();
+
+    this.errorInfoElement.textContent = err;
+    this.errorInfoElement.hidden = false;
+
+    if (this.timerId) {
+      clearTimeout(this.timerId);
+      this.timerId = null;
+    }
+
+    this.timerId = this.removeErrorMessage({ delay: 10000 });
+  },
+
+  removeErrorMessage({ delay }) {
+    this.initElements();
+
+    return setTimeout(() => {
+      this.errorInfoElement.textContent = '';
+      this.errorInfoElement.hidden = true;
+    }, delay);
+  },
+};
+
+export default errorHandler;

--- a/src/js/utils/perform-requests.js
+++ b/src/js/utils/perform-requests.js
@@ -1,0 +1,15 @@
+import errorsHandler from './errors-handler';
+
+const performRequests = async (promises) => {
+  let response;
+
+  try {
+    response = await Promise.all(promises);
+  } catch (err) {
+    errorsHandler.handle(err);
+  }
+
+  return response;
+};
+
+export default performRequests;


### PR DESCRIPTION
**Для более детальной информации об использовании и работе модуля смотри тело 5141b99 коммита**

В кратце:
`src/js/main.js` хранит примеры использования класса (сейчас в данный момент `develop` без токена авторизации не пустит дальше главного экрана и будет словно не видно, что модуль работает, но если залогиниться (вставить токен в localStorage) то всё будет хорошо) *(for details -> rslang/speakit)*

`src/js/settings.js` class Settings can be modified, has initialization, getting, setting of the settings :D

`src/js/utils/errors-handler.js` в нём есть генерирующийся DOM элемент и хранящийся в этом модуле (этот элемент должен иметь класс 'error-info'message'). По вызову .handle() можно запустить процесс обработки ошибок (element.textContent = errorText). Если появляется какая-то ошибка ещё, или запускается handle() более 1 раза в тайм-аут 10 секунд - то обнуляется предыдущий тайм-аут и выставляется новый в 10 секунд

`src/js/utils/perform-requests.js` имеет общую обёртку над всеми запросами со встроенной обработкой ошибок, который пытается запустить Promise.all(массив из промисов) и если есть ошибки, то вызывается .handle() из обработок ошибок, а если всё успешно - возвращает ответ от запроса

>  обновил Settings согласно последнему митингу. Если он вам нужен - можете взять отсюда https://github.com/Nastya07s/rslang/blob/speakit/src/js/settings.js
Вот пример его использования https://github.com/Nastya07s/rslang/blob/speakit/src/minigames/speakit/speakit.js
Можете расширить его, дописать, изменить
Потом энивэй будем смотреть что кого и унифицировать)

